### PR TITLE
set Content-Length header for generated zip

### DIFF
--- a/web/util/zip.js
+++ b/web/util/zip.js
@@ -55,6 +55,7 @@ class Zip {
       }
     );
     res.attachment(name + '.zip');
+    res.set('Content-Length', archive.pointer());
     archive.pipe(res);
     return archive;
   }


### PR DESCRIPTION
Set the Content-Length header when archiving the workflow to zip. Useful to know the size of the download beforehand.